### PR TITLE
[FEAT][EVA-9375]: when in the last page or less than one page, avoid count query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,18 @@ jobs:
     - name: Set up uv with Python 3.10
       uses: astral-sh/setup-uv@v4
       with:
-        enable-cache: true
         python-version: "3.10"
+
+    - name: Create virtual environment
+      run: uv venv
 
     - name: Install dependencies
       run: |
+        source .venv/bin/activate
         uv pip install -r requirements-dev.txt
         uv pip install -e .
 
     - name: Run tests
-      run: uv run pytest test/ -v
+      run: |
+        source .venv/bin/activate
+        uv run pytest test/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up uv with Python 3.10
+      uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        uv pip install -r requirements-dev.txt
+        uv pip install -e .
+
+    - name: Run tests
+      run: uv run pytest test/ -v

--- a/graphene_django_pagination/connection_field.py
+++ b/graphene_django_pagination/connection_field.py
@@ -118,7 +118,7 @@ class DjangoPaginationConnectionField(DjangoFilterConnectionField):
 
 
 def connection_from_list_slice(
-    iterable,
+    list_slice,
     args=None,
     connection_type=None,
     pageinfo_type=None,
@@ -130,7 +130,7 @@ def connection_from_list_slice(
 
     if limit is None:
         return connection_type(
-            results=iterable,
+            results=list_slice,
             page_info=pageinfo_type(
                 has_previous_page=False,
                 has_next_page=False
@@ -141,7 +141,7 @@ def connection_from_list_slice(
         assert limit > 0, "Limit must be positive integer greater than 0"
 
         # Fetch the requested slice
-        _slice = iterable[offset:(offset+limit)]
+        _slice = list_slice[offset:(offset+limit)]
         _slice_list = list(_slice)
         actual_count = len(_slice_list)
 
@@ -165,7 +165,7 @@ def connection_from_list_slice(
         else:
             # We got exactly 'limit' items, so we need to use the paginator
             # to determine if there are more pages (requires COUNT query)
-            paginator = Paginator(iterable, limit)
+            paginator = Paginator(list_slice, limit)
             total_count = paginator.count
 
             # Calculate has_previous/has_next based on offset, not page numbers

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="graphene-django-pagination",
-    version="0.0.3",
+    version="1.1.3",
     author="Instruct Developers",
     author_email="contato@instruct.com.br",
     description="This package adds offset-based pagination to Graphene-Django without using Graphene Relay.",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,4 +1,6 @@
 from django.test.client import RequestFactory
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
 import pytest
 
 from .fake_project import TestItem, schema
@@ -375,3 +377,127 @@ class TestTotalCount:
             result = client.execute(query)
             assert not result.get("errors"), f"Errors: {result.get('errors')}"
             assert result["data"]["items"]["totalCount"] == 8
+
+
+@pytest.mark.django_db
+class TestCountOptimization:
+    """Test count query optimization when items < limit"""
+
+    def test_last_page_skips_count_query(self, client, sample_data):
+        """Test that COUNT query is skipped when on last page with items < limit"""
+        # Query the last page where we have 2 items but limit is 3
+        query = """
+        query {
+            items(limit: 3, offset: 6) {
+                results {
+                    id
+                    name
+                    value
+                }
+                pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                }
+                totalCount
+            }
+        }
+        """
+
+        with CaptureQueriesContext(connection) as context:
+            result = client.execute(query)
+            assert not result.get("errors"), f"Errors: {result.get('errors')}"
+
+            # Verify the results are correct
+            data = result["data"]["items"]
+            assert len(data["results"]) == 2
+            assert data["totalCount"] == 8
+            assert data["pageInfo"]["hasNextPage"] == False
+            assert data["pageInfo"]["hasPreviousPage"] == True
+
+            # Check that no COUNT query was executed
+            # We should only have one SELECT query for fetching the items
+            queries = [q['sql'] for q in context.captured_queries]
+            count_queries = [q for q in queries if 'COUNT' in q.upper()]
+
+            assert len(count_queries) == 0, f"Expected no COUNT queries, but found: {count_queries}"
+
+    def test_first_page_partial_skips_count_query(self, client):
+        """Test that COUNT query is skipped on first page when total items < limit"""
+        # Create only 3 items but request limit of 5
+        TestItem.objects.all().delete()
+        items = [
+            TestItem(name="Apple", value=10),
+            TestItem(name="Banana", value=5),
+            TestItem(name="Cherry", value=15),
+        ]
+        TestItem.objects.bulk_create(items)
+
+        query = """
+        query {
+            items(limit: 5, offset: 0) {
+                results {
+                    id
+                    name
+                }
+                pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                }
+                totalCount
+            }
+        }
+        """
+
+        with CaptureQueriesContext(connection) as context:
+            result = client.execute(query)
+            assert not result.get("errors"), f"Errors: {result.get('errors')}"
+
+            # Verify the results are correct
+            data = result["data"]["items"]
+            assert len(data["results"]) == 3
+            assert data["totalCount"] == 3
+            assert data["pageInfo"]["hasNextPage"] == False
+            assert data["pageInfo"]["hasPreviousPage"] == False
+
+            # Check that no COUNT query was executed
+            queries = [q['sql'] for q in context.captured_queries]
+            count_queries = [q for q in queries if 'COUNT' in q.upper()]
+
+            assert len(count_queries) == 0, f"Expected no COUNT queries, but found: {count_queries}"
+
+    def test_middle_page_with_full_limit_does_count_query(self, client, sample_data):
+        """Test that COUNT query IS executed when we get exactly 'limit' items (not on last page)"""
+        # Query a middle page where we'll get exactly 'limit' items
+        # Since items == limit, we need COUNT to check if there are more pages
+        query = """
+        query {
+            items(limit: 3, offset: 3) {
+                results {
+                    id
+                    name
+                }
+                pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                }
+                totalCount
+            }
+        }
+        """
+
+        with CaptureQueriesContext(connection) as context:
+            result = client.execute(query)
+            assert not result.get("errors"), f"Errors: {result.get('errors')}"
+
+            # Verify the results are correct
+            data = result["data"]["items"]
+            assert len(data["results"]) == 3
+            assert data["totalCount"] == 8
+            assert data["pageInfo"]["hasNextPage"] == True
+            assert data["pageInfo"]["hasPreviousPage"] == True
+
+            # Check that a COUNT query WAS executed (since we got exactly 'limit' items)
+            queries = [q['sql'] for q in context.captured_queries]
+            count_queries = [q for q in queries if 'COUNT' in q.upper()]
+
+            assert len(count_queries) >= 1, f"Expected at least one COUNT query for middle page, but found: {count_queries}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mejoras**
  * Se optimizó la paginación para evitar consultas COUNT innecesarias en escenarios de última página, mejorando el rendimiento.

* **Tests**
  * Se añadió una suite de pruebas que valida la optimización de consultas en diferentes casos de paginación.

* **Chores**
  * Se configuró un flujo de trabajo automatizado en GitHub Actions para ejecutar pruebas en cada cambio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->