### PR TITLE
[FEAT][EVA-9416]: log when a query has too big of a limit.

### DIFF
--- a/graphene_django_pagination/connection_field.py
+++ b/graphene_django_pagination/connection_field.py
@@ -159,7 +159,7 @@ def connection_from_list_slice(
         info.context._CachedDjangoPaginationField = paginator.count
         try:
             if paginator.count >= MAX_LIMIT_TO_WARN:
-                logger.error(f"QUERY_SIZE_TEST_WARNING: Query returned {len(list_slice)} results, which is greater than {MAX_LIMIT_TO_WARN}. This may cause performance issues. Query: {info.operation.name.value}")
+                logger.error(f"QUERY_SIZE_TEST_WARNING: Query returned {paginator.count} results, which is greater than {MAX_LIMIT_TO_WARN}. This may cause performance issues. Query: {info.operation.name.value}")
         except:
             pass
         return connection_type(

--- a/graphene_django_pagination/connection_field.py
+++ b/graphene_django_pagination/connection_field.py
@@ -129,8 +129,11 @@ def connection_from_list_slice(
     offset = args.get("offset", 0)
 
     if limit is None:
-        if len(list_slice) >= MAX_LIMIT_TO_WARN:
-            logger.error(f"QUERY_SIZE_TEST_WARNING: Query returned {len(list_slice)} results, which is greater than {MAX_LIMIT_TO_WARN}. This may cause performance issues.")
+        try:
+            logger.error(f"QUERY_SIZE_TEST_WARNING: Unlimited query for query: {info.operation.name.value}")
+        except:
+            pass
+        
         return connection_type(
             results=list_slice,
             page_info=pageinfo_type(
@@ -154,9 +157,11 @@ def connection_from_list_slice(
         page = paginator.page(page_num)
 
         info.context._CachedDjangoPaginationField = paginator.count
-        if paginator.count >= MAX_LIMIT_TO_WARN:
-            logger.error(f"QUERY_SIZE_TEST_WARNING: Query returned {len(list_slice)} results, which is greater than {MAX_LIMIT_TO_WARN}. This may cause performance issues.")
-
+        try:
+            if paginator.count >= MAX_LIMIT_TO_WARN:
+                logger.error(f"QUERY_SIZE_TEST_WARNING: Query returned {len(list_slice)} results, which is greater than {MAX_LIMIT_TO_WARN}. This may cause performance issues. Query: {info.operation.name.value}")
+        except:
+            pass
         return connection_type(
             results=_slice,
             page_info=pageinfo_type(


### PR DESCRIPTION
# Context
First stage of the solution:
https://eva-pacs.atlassian.net/browse/EVA-9416

Just track the existence of unlimited queries and queries with too big of a limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **New Features**
  * Se añadió un sistema de advertencia automática que notifica cuando se detectan consultas de datos significativamente grandes, ayudando a identificar y optimizar operaciones que podrían afectar el rendimiento de la aplicación.

* **Chores**
  * Actualización de la plantilla estándar para solicitudes de extracción en el repositorio.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->