### PR TITLE
[FEAT][EVA-9520]: adds default limit

### DIFF
--- a/graphene_django_pagination/connection_field.py
+++ b/graphene_django_pagination/connection_field.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from functools import partial
 
@@ -8,6 +9,8 @@ from graphene_django.settings import graphene_settings
 from graphene_django.utils import maybe_queryset
 
 from . import PageInfoExtra, PaginationConnection
+
+logger = logging.getLogger(__name__)
 
 
 class DjangoPaginationConnectionField(DjangoFilterConnectionField):
@@ -131,8 +134,19 @@ def connection_from_list_slice(
     if max_limit is not None:
         if limit is None:
             limit = max_limit
-        else:
-            limit = min(limit, max_limit)
+        elif limit > max_limit:
+            try:
+                operation_name = info.operation.name.value
+            except Exception:
+                operation_name = "unknown"
+            logger.warning(
+                "Query '%s' limit %d exceeded max_limit %d, capping to %d",
+                operation_name,
+                limit,
+                max_limit,
+                max_limit,
+            )
+            limit = max_limit
 
     if limit is None:
         return connection_type(

--- a/graphene_django_pagination/connection_field.py
+++ b/graphene_django_pagination/connection_field.py
@@ -21,7 +21,6 @@ class DjangoPaginationConnectionField(DjangoFilterConnectionField):
         order_by=None,
         extra_filter_meta=None,
         filterset_class=None,
-        hard_limit=None,
         *args,
         **kwargs,
     ):
@@ -31,8 +30,7 @@ class DjangoPaginationConnectionField(DjangoFilterConnectionField):
         self._filterset_class = None
         self._extra_filter_meta = extra_filter_meta
         self._base_args = None
-        self._hard_limit = hard_limit or graphene_settings.RELAY_CONNECTION_MAX_LIMIT
-
+        kwargs["max_limit"] = kwargs.get("max_limit") or graphene_settings.RELAY_CONNECTION_MAX_LIMIT
         kwargs.setdefault("limit", Int(description="Query limit"))
         kwargs.setdefault("offset", Int(description="Query offset"))
         kwargs.setdefault("ordering", String(description="Query order"))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="graphene-django-pagination",
-    version="1.1.3",
+    version="1.1.5",
     author="Instruct Developers",
     author_email="contato@instruct.com.br",
     description="This package adds offset-based pagination to Graphene-Django without using Graphene Relay.",

--- a/test/fake_project.py
+++ b/test/fake_project.py
@@ -32,10 +32,25 @@ class TestItemType(DjangoObjectType):
         }
 
 
+class TestItemLimitedType(DjangoObjectType):
+    class Meta:
+        model = TestItem
+        name = 'TestItemLimited'
+        fields = ('id', 'name', 'value')
+        filter_fields = {
+            'name': ['exact', 'icontains'],
+            'value': ['exact', 'gte', 'lte'],
+        }
+
+
 class Query(ObjectType):
     items = DjangoPaginationConnectionField(TestItemType)
+    items_limited = DjangoPaginationConnectionField(TestItemLimitedType, max_limit=3)
     
     def resolve_items(self, info, **kwargs):
+        return TestItem.objects.all()
+
+    def resolve_items_limited(self, info, **kwargs):
         return TestItem.objects.all()
 
 


### PR DESCRIPTION
## Context

Respect RELAY_CONNECTION_MAX_LIMIT, allowing the user to define a max limit.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Nuevas Características**
  * Se agregó capacidad de establecer un límite máximo en consultas paginadas para controlar el número de resultados devueltos en cada solicitud.

* **Pruebas**
  * Se añadieron pruebas exhaustivas para verificar el comportamiento del límite máximo en diferentes escenarios de paginación, incluyendo casos con límites excedidos y con desplazamiento.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->